### PR TITLE
feat: add continueOnError option

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ run();
 
 - **Type:** `string`
 - **Required:** No
-- **Description:** Slug of the App for build uploads. When provided in combination with `buildPath`, the build is uploaded under this specified App.
+- **Description:** The slug of the app on the TV Labs platform to use to upload the build. When not provided, the organization's default app is used. You may find or create an app on the [Apps page](https://tvlabs.ai/app/apps) in the TV Labs platform.
 
 ### `retries`
 
@@ -134,3 +134,10 @@ run();
 - **Required:** No
 - **Default:** `true`
 - **Description:** Controls whether or not to attach an `x-request-id` header to each request made to the TV Labs platform.
+
+### `continueOnError`
+
+- **Type:** `boolean`
+- **Required:** No
+- **Default:** `false`
+- **Description:** Whether to continue the session request if any step fails. When `true`, the session request will still be made with the original provided capabilities. When `false`, the service will exit with a non-zero code.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tvlabs/wdio-service",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "description": "WebdriverIO service that provides a better integration into TV Labs",
   "author": "Regan Karlewicz <regan@tvlabs.ai>",
   "license": "Apache-2.0",

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,6 +11,7 @@ export type TVLabsServiceOptions = {
   app?: string;
   reconnectRetries?: number;
   attachRequestId?: boolean;
+  continueOnError?: boolean;
 };
 
 export type TVLabsCapabilities =


### PR DESCRIPTION
- Change default behavior to exit with non-zero status code on error
- Add `continueOnError` option to allow request to continue if desired
- Update README options description
- Fix logger name